### PR TITLE
Add semantic search for categorical fields and LLM fallback models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 GOOGLE_API_KEY=your-key-here
+GEMINI_FALLBACK_MODELS=gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash
+
+# Typesense (semantic search)
+TYPESENSE_HOST=localhost
+TYPESENSE_PORT=8108
+TYPESENSE_API_KEY=xyz
+TYPESENSE_COLLECTION=field_values
 
 # LangSmith observability (optional)
 LANGSMITH_TRACING=true

--- a/app/agent.py
+++ b/app/agent.py
@@ -8,8 +8,14 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.tools import tool
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-from app.config import GEMINI_MODEL, GEMINI_TEMPERATURE, GOOGLE_API_KEY
+from app.config import (
+    GEMINI_FALLBACK_MODELS,
+    GEMINI_MODEL,
+    GEMINI_TEMPERATURE,
+    GOOGLE_API_KEY,
+)
 from app.db import run_aggregate, run_distinct, run_find
+from app.search import search_similar_values
 
 SYSTEM_PROMPT = """You are a procurement data analyst assistant. You answer questions about California state government purchase order data (2012–2015) stored in a MongoDB collection called `procurement.purchases`.
 
@@ -58,6 +64,15 @@ Each document has these fields:
 - Prices (Unit Price, Total Price) are floats, NOT strings. Query them numerically.
 - Fiscal Year is a string like "2013-2014".
 - For text matching, use exact match or `{"$regex": "pattern", "$options": "i"}` for case-insensitive.
+- When a user refers to a department, supplier, or item by name, first try querying MongoDB directly. If the query returns zero results, the name was probably informal or abbreviated — use `find_similar_values` to resolve it to the exact database value, then re-query.
+- When `find_similar_values` returns multiple matches, present them as a **numbered list** to the user and ask which one they meant. Do NOT dump raw JSON. Format like:
+  "I found several possible matches for 'Health Department':
+   1. Health Care Services, Department of
+   2. Public Health, Department of
+   3. Mental Health, Department of
+   Which one did you mean?"
+  Once the user picks one, use that exact value in your MongoDB query.
+- If `find_similar_values` returns exactly one match with a very low score (< 0.3), you may use it directly without asking.
 - For "top N" or "highest/lowest" questions, use aggregation with $group, $sort, $limit.
 - For counting, use aggregation with $group and $count, or $match followed by $count.
 - For sums/averages, use $group with $sum/$avg on numeric fields.
@@ -80,6 +95,27 @@ Each document has these fields:
 ```
 
 Always use the tools to query the database. Do not make up data. Present results clearly, with formatting (tables, lists) where appropriate."""
+
+
+def _extract_text(content: Any) -> str:
+    """Extract plain text from an LLM response content field.
+
+    LangChain model responses may return content as a plain string or as a list
+    of content blocks (e.g. [{"type": "text", "text": "...", "extras": {...}}]).
+    This normalises both forms to a plain string suitable for display and for
+    feeding back into conversation history.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block["text"])
+            elif isinstance(block, str):
+                parts.append(block)
+        return "\n".join(parts)
+    return str(content)
 
 
 def _parse_dates(obj: Any) -> Any:
@@ -159,18 +195,52 @@ def get_distinct_values(field: str) -> str:
     return run_distinct(field)
 
 
-TOOLS = [query_mongodb, aggregate_mongodb, get_distinct_values]
+@tool
+def find_similar_values(query: str, field_name: str, limit: int = 5) -> str:
+    """Find database values that semantically match a user's natural-language term.
+
+    Use this when the user refers to a department, supplier, item, or other
+    categorical field by an informal or abbreviated name. It returns the closest
+    exact values stored in the database so you can build accurate MongoDB queries.
+
+    Args:
+        query: The user's term, e.g. "Health Department" or "Dell".
+        field_name: The collection field to search within, e.g. "Department Name",
+                    "Supplier Name", "Item Name", "Acquisition Type",
+                    "Acquisition Method".
+        limit: Maximum number of matches to return (default 5).
+
+    Returns:
+        JSON string of matches, each with "value" and "score" keys.
+        Lower score means a closer match.
+        Present the matches as a numbered list to the user and ask them
+        to pick one — do NOT show raw JSON to the user.
+    """
+    results = search_similar_values(query, field_name, limit)
+    return json.dumps(results)
+
+
+TOOLS = [query_mongodb, aggregate_mongodb, get_distinct_values, find_similar_values]
 
 
 def build_agent():
     """Build and return a LangChain tool-calling agent."""
-    llm = ChatGoogleGenerativeAI(
+    primary = ChatGoogleGenerativeAI(
         model=GEMINI_MODEL,
         temperature=GEMINI_TEMPERATURE,
         google_api_key=GOOGLE_API_KEY,
     )
-    llm_with_tools = llm.bind_tools(TOOLS)
-    return llm_with_tools
+    fallbacks = [
+        ChatGoogleGenerativeAI(
+            model=model,
+            temperature=GEMINI_TEMPERATURE,
+            google_api_key=GOOGLE_API_KEY,
+        )
+        for model in GEMINI_FALLBACK_MODELS
+        if model != GEMINI_MODEL
+    ]
+    llm = primary.with_fallbacks(fallbacks) if fallbacks else primary
+    return llm.bind_tools(TOOLS)
 
 
 def run_agent(user_input: str, history: list[dict], llm=None) -> str:
@@ -199,20 +269,25 @@ def run_agent(user_input: str, history: list[dict], llm=None) -> str:
     # Agentic loop: call LLM, invoke tools, repeat until no more tool calls
     for _ in range(10):  # max iterations to prevent infinite loops
         response = llm.invoke(messages)
-        messages.append(response)
 
         if not response.tool_calls:
-            return response.content
+            return _extract_text(response.content)
+
+        # Keep the full response object in messages for LangChain's
+        # tool-call tracking, but replace content with plain text so
+        # later turns don't re-send model metadata (signatures, etc.).
+        response.content = _extract_text(response.content)
+        messages.append(response)
 
         # Execute each tool call and append results
+        from langchain_core.messages import ToolMessage
+
         for tc in response.tool_calls:
             tool_fn = tools_by_name[tc["name"]]
             result = tool_fn.invoke(tc["args"])
-            from langchain_core.messages import ToolMessage
-
             messages.append(
                 ToolMessage(content=str(result), tool_call_id=tc["id"])
             )
 
     # If we exhausted iterations, return whatever we have
-    return response.content
+    return _extract_text(response.content)

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ import os
 
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 
 GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY", "")
 MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
@@ -12,3 +12,16 @@ DB_NAME = os.getenv("DB_NAME", "procurement")
 COLLECTION_NAME = os.getenv("COLLECTION_NAME", "purchases")
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")
 GEMINI_TEMPERATURE = float(os.getenv("GEMINI_TEMPERATURE", "0"))
+
+_fallback_raw = os.getenv(
+    "GEMINI_FALLBACK_MODELS",
+    "gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash",
+)
+GEMINI_FALLBACK_MODELS: list[str] = [
+    m.strip() for m in _fallback_raw.split(",") if m.strip()
+]
+
+TYPESENSE_HOST = os.getenv("TYPESENSE_HOST", "localhost")
+TYPESENSE_PORT = os.getenv("TYPESENSE_PORT", "8108")
+TYPESENSE_API_KEY = os.getenv("TYPESENSE_API_KEY", "xyz")
+TYPESENSE_COLLECTION = os.getenv("TYPESENSE_COLLECTION", "field_values")

--- a/app/search.py
+++ b/app/search.py
@@ -1,0 +1,92 @@
+
+"""Typesense vector search for resolving user intent to exact field values."""
+
+from app.config import (
+    TYPESENSE_API_KEY,
+    TYPESENSE_COLLECTION,
+    TYPESENSE_HOST,
+    TYPESENSE_PORT,
+)
+
+_client = None
+_embedding_model = None
+
+
+def get_typesense_client():
+    """Return a lazily-initialised Typesense client."""
+    import typesense
+
+    global _client
+    if _client is None:
+        _client = typesense.Client(
+            {
+                "nodes": [
+                    {
+                        "host": TYPESENSE_HOST,
+                        "port": TYPESENSE_PORT,
+                        "protocol": "http",
+                    }
+                ],
+                "api_key": TYPESENSE_API_KEY,
+                "connection_timeout_seconds": 5,
+            }
+        )
+    return _client
+
+
+def _get_embedding_model():
+    """Return a lazily-loaded sentence-transformer model."""
+    from sentence_transformers import SentenceTransformer
+
+    global _embedding_model
+    if _embedding_model is None:
+        _embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
+    return _embedding_model
+
+
+def embed_text(text: str) -> list[float]:
+    """Embed a single string. Swap this function to change the embedding model."""
+    model = _get_embedding_model()
+    return model.encode(text).tolist()
+
+
+def search_similar_values(
+    query: str,
+    field_name: str,
+    limit: int = 5,
+) -> list[dict]:
+    """Embed *query* and vector-search Typesense for the closest field values.
+
+    Args:
+        query: The user's natural-language term (e.g. "Health Department").
+        field_name: Which field to search within (e.g. "Department Name").
+        limit: Maximum number of results to return.
+
+    Returns:
+        List of dicts with ``value`` and ``score`` keys.
+    """
+    client = get_typesense_client()
+    query_embedding = embed_text(query)
+
+    # Use multi_search (POST) to avoid URL length limits with 384-dim vectors.
+    results = client.multi_search.perform(
+        {
+            "searches": [
+                {
+                    "collection": TYPESENSE_COLLECTION,
+                    "q": "*",
+                    "filter_by": f"field_name:={field_name}",
+                    "vector_query": f"embedding:([{','.join(str(v) for v in query_embedding)}], k:{limit})",
+                }
+            ]
+        },
+        {},
+    )
+
+    return [
+        {
+            "value": hit["document"]["value"],
+            "score": hit["vector_distance"],
+        }
+        for hit in results["results"][0]["hits"]
+    ]

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -10,19 +10,32 @@ st.caption("Ask questions about California state purchase order data (2012–201
 
 # --- Sidebar with example queries ---
 with st.sidebar:
-    st.header("Example Queries")
-    examples = [
+    st.header("Exact Match")
+    st.caption("These use exact field values — no semantic resolution needed.")
+    exact_examples = [
         "How many orders were created in 2013?",
-        "Which quarter had the highest total spending?",
-        "What are the top 10 most frequently ordered items?",
         "Show me the total spending by department for fiscal year 2014-2015",
+        "What are the top 10 most frequently ordered items?",
         "Which suppliers have the most orders?",
-        "What is the average order value by acquisition type?",
-        "How many orders used CalCard?",
         "What are the distinct fiscal years in the dataset?",
     ]
-    for example in examples:
+    for example in exact_examples:
         if st.button(example, use_container_width=True):
+            st.session_state["pending_query"] = example
+
+    st.divider()
+    st.header("Semantic Search")
+    st.caption(
+        "These use informal names the agent must resolve to exact DB values "
+        "via vector search (e.g. 'Health Department' → 'Health Care Services, Department of')."
+    )
+    semantic_examples = [
+        "How many orders from the Health Department?",
+        "Total spending by the DMV last year?",
+        "What did Corrections buy the most?",
+    ]
+    for example in semantic_examples:
+        if st.button(example, use_container_width=True, key=f"sem_{example}"):
             st.session_state["pending_query"] = example
 
 # --- Chat state ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,15 @@ services:
     volumes:
       - mongo_data:/data/db
 
+  typesense:
+    image: typesense/typesense:27.1
+    container_name: procurement-typesense
+    ports:
+      - "8108:8108"
+    volumes:
+      - typesense_data:/data
+    command: "--data-dir /data --api-key=xyz --enable-cors"
+
 volumes:
   mongo_data:
+  typesense_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "langchain-core>=0.3",
     "streamlit>=1.39",
     "python-dotenv>=1.0",
+    "typesense>=0.21",
+    "sentence-transformers>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/index_typesense.py
+++ b/scripts/index_typesense.py
@@ -1,0 +1,84 @@
+"""Index distinct MongoDB field values into Typesense for semantic search.
+
+Idempotent: drops and recreates the collection on every run.
+
+Usage:
+    python scripts/index_typesense.py
+"""
+
+import hashlib
+
+from pymongo import MongoClient
+
+from app.config import (
+    COLLECTION_NAME,
+    DB_NAME,
+    MONGO_URI,
+    TYPESENSE_COLLECTION,
+)
+from app.search import embed_text, get_typesense_client
+
+# Fields whose distinct values we want to make searchable.
+TARGET_FIELDS = [
+    "Department Name",
+    "Supplier Name",
+    "Item Name",
+    "Acquisition Type",
+    "Acquisition Method",
+]
+
+COLLECTION_SCHEMA = {
+    "name": TYPESENSE_COLLECTION,
+    "fields": [
+        {"name": "field_name", "type": "string", "facet": True},
+        {"name": "value", "type": "string"},
+        {"name": "embedding", "type": "float[]", "num_dim": 384},
+    ],
+}
+
+
+def _stable_id(field_name: str, value: str) -> str:
+    """Deterministic document id so upserts are safe."""
+    return hashlib.sha256(f"{field_name}:{value}".encode()).hexdigest()[:16]
+
+
+def main() -> None:
+    client = get_typesense_client()
+
+    # Drop existing collection (idempotent).
+    try:
+        client.collections[TYPESENSE_COLLECTION].delete()
+        print(f"Dropped existing collection '{TYPESENSE_COLLECTION}'")
+    except Exception:
+        pass
+
+    client.collections.create(COLLECTION_SCHEMA)
+    print(f"Created collection '{TYPESENSE_COLLECTION}'")
+
+    # Connect to MongoDB.
+    mongo = MongoClient(MONGO_URI)
+    collection = mongo[DB_NAME][COLLECTION_NAME]
+
+    total = 0
+    for field in TARGET_FIELDS:
+        values = collection.distinct(field)
+        values = [v for v in values if v is not None and str(v).strip()]
+        print(f"  {field}: {len(values)} distinct values")
+
+        for value in values:
+            str_value = str(value)
+            doc = {
+                "id": _stable_id(field, str_value),
+                "field_name": field,
+                "value": str_value,
+                "embedding": embed_text(str_value),
+            }
+            client.collections[TYPESENSE_COLLECTION].documents.upsert(doc)
+            total += 1
+
+    print(f"Indexed {total} documents into '{TYPESENSE_COLLECTION}'")
+    mongo.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/evaluation.json
+++ b/tests/evaluation.json
@@ -57,5 +57,21 @@
         }
       }
     ]
+  },
+  {
+    "id": "health-dept-semantic",
+    "tags": ["semantic-search", "aggregation", "count"],
+    "_comment": "Semantic search test: user says 'Health Department' but the DB value is 'Health Care Services, Department of'. Tests that fuzzy/informal names resolve to exact DB values via vector search.",
+    "question": "How many orders from the Health Department?",
+    "expected_values": ["Health Care Services"],
+    "tool_calls": [
+      {
+        "name": "find_similar_values",
+        "args": {
+          "query": "Health Department",
+          "field_name": "Department Name"
+        }
+      }
+    ]
   }
 ]

--- a/tests/integration_tests/test_agent.py
+++ b/tests/integration_tests/test_agent.py
@@ -8,6 +8,7 @@ Requires MongoDB running with procurement data loaded.
 
 import json
 import pathlib
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import AIMessage
@@ -30,6 +31,17 @@ def _final_response(text):
 
 
 # ── Data-driven tests from evaluation.json ───────────────────────────
+
+# Cases that hit Typesense need the search backend mocked.
+_SEARCH_MOCK_RETURN = [
+    {"value": "Health Care Services, Department of", "score": 0.12},
+]
+
+
+def _needs_search_mock(case):
+    return any(tc["name"] == "find_similar_values" for tc in case["tool_calls"])
+
+
 @pytest.mark.parametrize(
     "case",
     EVAL_CASES,
@@ -45,7 +57,15 @@ def test_tool_dispatch(case, mongo_collection):
     final = _final_response("Done.")
 
     mock_llm = make_mock_llm([tool_call_response, final])
-    result = run_agent(case["question"], [], llm=mock_llm)
+
+    if _needs_search_mock(case):
+        with patch(
+            "app.agent.search_similar_values",
+            return_value=_SEARCH_MOCK_RETURN,
+        ):
+            result = run_agent(case["question"], [], llm=mock_llm)
+    else:
+        result = run_agent(case["question"], [], llm=mock_llm)
 
     assert result == "Done."
     assert mock_llm.call_count == 2
@@ -93,3 +113,91 @@ class TestNoToolCalls:
 
         assert result == "I can help with procurement data queries."
         assert mock_llm.call_count == 1
+
+
+class TestFindSimilarValues:
+    """Integration tests for the find_similar_values tool.
+
+    These test semantic search resolution — the user says an informal name
+    like "Health Department" and the tool resolves it to the exact DB value
+    "Health Care Services, Department of".  The wording gap (different words,
+    different order) is what makes this a semantic match, not an exact one.
+
+    Mocks the search backend (Typesense + embeddings) since it may not be
+    running, but exercises the full agent tool-dispatch path.
+    """
+
+    @patch("app.agent.search_similar_values")
+    def test_tool_dispatches_and_returns_results(self, mock_search):
+        """Verify the agent dispatches find_similar_values with the right args.
+
+        User says "Health Department" — not an exact match for any DB value.
+        The tool should resolve it to "Health Care Services, Department of".
+        """
+        mock_search.return_value = [
+            {"value": "Health Care Services, Department of", "score": 0.12},
+            {"value": "Public Health, Department of", "score": 0.25},
+        ]
+
+        tool_call_response = _ai_with_tool_calls([
+            {
+                "id": "call_0",
+                "name": "find_similar_values",
+                "args": {
+                    "query": "Health Department",
+                    "field_name": "Department Name",
+                },
+            },
+        ])
+        final = _final_response("The closest match is Health Care Services, Department of.")
+
+        mock_llm = make_mock_llm([tool_call_response, final])
+        result = run_agent("orders from Health Department", [], llm=mock_llm)
+
+        assert result == "The closest match is Health Care Services, Department of."
+        mock_search.assert_called_once_with(
+            "Health Department", "Department Name", 5
+        )
+
+    @patch("app.agent.search_similar_values")
+    def test_chained_with_mongodb_query(self, mock_search, mongo_collection):
+        """Full two-step flow: resolve informal name, then query MongoDB.
+
+        Turn 1 — LLM calls find_similar_values("Health Department")
+                  → returns "Health Care Services, Department of"
+        Turn 2 — LLM uses that exact value to query MongoDB
+        Turn 3 — LLM returns final answer
+        """
+        mock_search.return_value = [
+            {"value": "Health Care Services, Department of", "score": 0.1},
+        ]
+
+        search_call = _ai_with_tool_calls([
+            {
+                "id": "call_0",
+                "name": "find_similar_values",
+                "args": {
+                    "query": "Health Department",
+                    "field_name": "Department Name",
+                },
+            },
+        ])
+        mongo_call = _ai_with_tool_calls([
+            {
+                "id": "call_1",
+                "name": "aggregate_mongodb",
+                "args": {
+                    "pipeline": json.dumps([
+                        {"$match": {"Department Name": "Health Care Services, Department of"}},
+                        {"$count": "total"},
+                    ])
+                },
+            },
+        ])
+        final = _final_response("Found 42 orders.")
+
+        mock_llm = make_mock_llm([search_call, mongo_call, final])
+        result = run_agent("How many orders from Health Department?", [], llm=mock_llm)
+
+        assert result == "Found 42 orders."
+        assert mock_llm.call_count == 3

--- a/tests/unit_tests/test_agent.py
+++ b/tests/unit_tests/test_agent.py
@@ -1,0 +1,36 @@
+"""Unit tests for agent construction and fallback chain."""
+
+from unittest.mock import patch
+
+from langchain_core.runnables import RunnableWithFallbacks
+
+from app.agent import build_agent
+
+
+@patch("app.agent.GOOGLE_API_KEY", "fake-key")
+@patch("app.agent.GEMINI_MODEL", "gemini-primary")
+@patch("app.agent.GEMINI_FALLBACK_MODELS", ["gemini-fallback-1", "gemini-fallback-2"])
+def test_build_agent_with_fallbacks():
+    agent = build_agent()
+    # bind_tools on a RunnableWithFallbacks returns a RunnableWithFallbacks
+    # whose .runnable is the primary's RunnableBinding and .fallbacks has one
+    # RunnableBinding per fallback model.
+    assert isinstance(agent, RunnableWithFallbacks)
+    assert len(agent.fallbacks) == 2
+
+
+@patch("app.agent.GOOGLE_API_KEY", "fake-key")
+@patch("app.agent.GEMINI_MODEL", "gemini-primary")
+@patch("app.agent.GEMINI_FALLBACK_MODELS", [])
+def test_build_agent_without_fallbacks():
+    agent = build_agent()
+    assert not isinstance(agent, RunnableWithFallbacks)
+
+
+@patch("app.agent.GOOGLE_API_KEY", "fake-key")
+@patch("app.agent.GEMINI_MODEL", "gemini-primary")
+@patch("app.agent.GEMINI_FALLBACK_MODELS", ["gemini-primary"])
+def test_build_agent_skips_primary_in_fallbacks():
+    """Fallback list that only contains the primary model should produce no fallbacks."""
+    agent = build_agent()
+    assert not isinstance(agent, RunnableWithFallbacks)

--- a/tests/unit_tests/test_extract_text.py
+++ b/tests/unit_tests/test_extract_text.py
@@ -1,0 +1,59 @@
+"""Level 1: Unit tests for _extract_text() from app/agent.py."""
+
+from app.agent import _extract_text
+
+
+class TestExtractTextPlainString:
+    def test_returns_string_unchanged(self):
+        assert _extract_text("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert _extract_text("") == ""
+
+
+class TestExtractTextContentBlocks:
+    """LLM responses may come back as a list of typed content blocks."""
+
+    def test_single_text_block(self):
+        content = [{"type": "text", "text": "The answer is 42."}]
+        assert _extract_text(content) == "The answer is 42."
+
+    def test_multiple_text_blocks(self):
+        content = [
+            {"type": "text", "text": "Part one."},
+            {"type": "text", "text": "Part two."},
+        ]
+        assert _extract_text(content) == "Part one.\nPart two."
+
+    def test_ignores_extras_and_metadata(self):
+        """Gemini responses include extras with signatures — these must be stripped."""
+        content = [
+            {
+                "type": "text",
+                "text": "There were 6953 orders.",
+                "extras": {"signature": "CqYDAXLI2nw..."},
+            }
+        ]
+        assert _extract_text(content) == "There were 6953 orders."
+
+    def test_ignores_non_text_blocks(self):
+        content = [
+            {"type": "text", "text": "Answer."},
+            {"type": "image", "data": "..."},
+        ]
+        assert _extract_text(content) == "Answer."
+
+    def test_list_of_plain_strings(self):
+        content = ["hello", "world"]
+        assert _extract_text(content) == "hello\nworld"
+
+    def test_empty_list(self):
+        assert _extract_text([]) == ""
+
+
+class TestExtractTextFallback:
+    def test_non_string_non_list(self):
+        assert _extract_text(123) == "123"
+
+    def test_none(self):
+        assert _extract_text(None) == "None"

--- a/tests/unit_tests/test_index_typesense.py
+++ b/tests/unit_tests/test_index_typesense.py
@@ -1,0 +1,25 @@
+"""Level 1: Unit tests for scripts/index_typesense.py."""
+
+from scripts.index_typesense import _stable_id
+
+
+class TestStableId:
+    def test_deterministic(self):
+        id1 = _stable_id("Department Name", "Health Care Services, Department of")
+        id2 = _stable_id("Department Name", "Health Care Services, Department of")
+        assert id1 == id2
+
+    def test_different_values_produce_different_ids(self):
+        id1 = _stable_id("Department Name", "Health Care Services, Department of")
+        id2 = _stable_id("Department Name", "Public Health, Department of")
+        assert id1 != id2
+
+    def test_different_fields_same_value_produce_different_ids(self):
+        id1 = _stable_id("Department Name", "Labor")
+        id2 = _stable_id("Item Name", "Labor")
+        assert id1 != id2
+
+    def test_returns_hex_string(self):
+        result = _stable_id("field", "value")
+        assert len(result) == 16
+        int(result, 16)  # raises ValueError if not valid hex

--- a/tests/unit_tests/test_search.py
+++ b/tests/unit_tests/test_search.py
@@ -1,0 +1,96 @@
+"""Level 1: Unit tests for app/search.py — embedding and vector search."""
+
+from unittest.mock import MagicMock, patch
+
+from app.search import embed_text, search_similar_values
+
+
+class TestEmbedText:
+    @patch("app.search._get_embedding_model")
+    def test_returns_list_of_floats(self, mock_get_model):
+        import numpy as np
+
+        fake_model = MagicMock()
+        fake_model.encode.return_value = np.array([0.1, 0.2, 0.3])
+        mock_get_model.return_value = fake_model
+
+        result = embed_text("hello")
+
+        assert result == [0.1, 0.2, 0.3]
+        fake_model.encode.assert_called_once_with("hello")
+
+    @patch("app.search._get_embedding_model")
+    def test_converts_numpy_to_plain_list(self, mock_get_model):
+        import numpy as np
+
+        fake_model = MagicMock()
+        fake_model.encode.return_value = np.zeros(384, dtype=np.float32)
+        mock_get_model.return_value = fake_model
+
+        result = embed_text("test")
+
+        assert isinstance(result, list)
+        assert len(result) == 384
+        assert all(isinstance(v, float) for v in result)
+
+
+def _mock_multi_search(hits):
+    """Create a mock Typesense client whose multi_search.perform returns *hits*."""
+    mock_client = MagicMock()
+    mock_client.multi_search.perform.return_value = {
+        "results": [{"hits": hits}]
+    }
+    return mock_client
+
+
+class TestSearchSimilarValues:
+    @patch("app.search.embed_text")
+    @patch("app.search.get_typesense_client")
+    def test_returns_matches_with_value_and_score(
+        self, mock_client_fn, mock_embed
+    ):
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_client_fn.return_value = _mock_multi_search([
+            {
+                "document": {
+                    "field_name": "Department Name",
+                    "value": "Health Care Services, Department of",
+                },
+                "vector_distance": 0.12,
+            },
+            {
+                "document": {
+                    "field_name": "Department Name",
+                    "value": "Public Health, Department of",
+                },
+                "vector_distance": 0.25,
+            },
+        ])
+
+        results = search_similar_values("Health Department", "Department Name", limit=2)
+
+        assert len(results) == 2
+        assert results[0]["value"] == "Health Care Services, Department of"
+        assert results[0]["score"] == 0.12
+        assert results[1]["value"] == "Public Health, Department of"
+
+    @patch("app.search.embed_text")
+    @patch("app.search.get_typesense_client")
+    def test_filters_by_field_name(self, mock_client_fn, mock_embed):
+        mock_embed.return_value = [0.1]
+        mock_client_fn.return_value = _mock_multi_search([])
+
+        search_similar_values("Dell", "Supplier Name", limit=3)
+
+        call_args = mock_client_fn.return_value.multi_search.perform.call_args[0][0]
+        assert call_args["searches"][0]["filter_by"] == "field_name:=Supplier Name"
+
+    @patch("app.search.embed_text")
+    @patch("app.search.get_typesense_client")
+    def test_empty_results(self, mock_client_fn, mock_embed):
+        mock_embed.return_value = [0.1]
+        mock_client_fn.return_value = _mock_multi_search([])
+
+        results = search_similar_values("nonexistent", "Department Name")
+
+        assert results == []


### PR DESCRIPTION
## Summary
- Add `find_similar_values` tool backed by Typesense vector search to resolve informal field names to exact DB values
- Add LLM fallback chain via `with_fallbacks()` so rate-limit errors on the primary Gemini model fall through to alternatives
- Fix `load_dotenv(override=True)` so `.env` values always take precedence over shell env vars
- Add Typesense to docker-compose and indexing script
- Add unit and integration tests for new functionality

## Test plan
- [x] Run `pytest tests/unit_tests/` — all 47 tests pass
- [ ] Run `pytest tests/integration_tests/` with MongoDB running
- [x] Verify semantic search resolves informal names (e.g. "Health Department" → "Health Care Services, Department of")
- [x] Verify fallback kicks in when primary model is rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)