### PR TITLE
Add fuzzy text search for supplier fields

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -15,7 +15,7 @@ from app.config import (
     GOOGLE_API_KEY,
 )
 from app.db import run_aggregate, run_distinct, run_find
-from app.search import search_similar_values
+from app.search import search_fuzzy, search_similar_values
 
 SYSTEM_PROMPT = """You are a procurement data analyst assistant. You answer questions about California state government purchase order data (2012–2015) stored in a MongoDB collection called `procurement.purchases`.
 
@@ -64,7 +64,8 @@ Each document has these fields:
 - Prices (Unit Price, Total Price) are floats, NOT strings. Query them numerically.
 - Fiscal Year is a string like "2013-2014".
 - For text matching, use exact match or `{"$regex": "pattern", "$options": "i"}` for case-insensitive.
-- When a user refers to a department, supplier, or item by name, first try querying MongoDB directly. If the query returns zero results, the name was probably informal or abbreviated — use `find_similar_values` to resolve it to the exact database value, then re-query.
+- When a user refers to a department or item by name, first try querying MongoDB directly. If the query returns zero results, the name was probably informal or abbreviated — use `find_similar_values` to resolve it to the exact database value, then re-query.
+- When a user refers to a supplier by name, code, or zip code, use `find_supplier` to resolve it. This uses typo-tolerant text matching suited for proper nouns (e.g. "Pitney" → "Pitney Bowes").
 - When `find_similar_values` returns multiple matches, present them as a **numbered list** to the user and ask which one they meant. Do NOT dump raw JSON. Format like:
   "I found several possible matches for 'Health Department':
    1. Health Care Services, Department of
@@ -220,7 +221,31 @@ def find_similar_values(query: str, field_name: str, limit: int = 5) -> str:
     return json.dumps(results)
 
 
-TOOLS = [query_mongodb, aggregate_mongodb, get_distinct_values, find_similar_values]
+@tool
+def find_supplier(query: str, field_name: str = "Supplier Name", limit: int = 5) -> str:
+    """Find suppliers by name, code, or zip code using typo-tolerant text search.
+
+    Use this when the user refers to a supplier by a partial, abbreviated, or
+    misspelled name. Unlike find_similar_values (which uses meaning-based
+    search), this uses fuzzy text matching suited for proper nouns.
+
+    Args:
+        query: The user's term, e.g. "Pitney", "Delta Dental", "95841".
+        field_name: The supplier field to search: "Supplier Name",
+                    "Supplier Code", or "Supplier Zip Code".
+        limit: Maximum number of matches to return (default 5).
+
+    Returns:
+        JSON string of matches, each with "value" and "score" keys.
+        Higher score means a closer match.
+        Present the matches as a numbered list to the user and ask them
+        to pick one — do NOT show raw JSON to the user.
+    """
+    results = search_fuzzy(query, field_name, limit)
+    return json.dumps(results)
+
+
+TOOLS = [query_mongodb, aggregate_mongodb, get_distinct_values, find_similar_values, find_supplier]
 
 
 def build_agent():

--- a/app/search.py
+++ b/app/search.py
@@ -1,5 +1,10 @@
 
-"""Typesense vector search for resolving user intent to exact field values."""
+"""Typesense search for resolving user intent to exact field values.
+
+Two strategies:
+- Vector/semantic search for categorical fields (Department Name, etc.)
+- Text/fuzzy search for proper nouns (Supplier Name, Supplier Code, etc.)
+"""
 
 from app.config import (
     TYPESENSE_API_KEY,
@@ -89,4 +94,42 @@ def search_similar_values(
             "score": hit["vector_distance"],
         }
         for hit in results["results"][0]["hits"]
+    ]
+
+
+def search_fuzzy(
+    query: str,
+    field_name: str,
+    limit: int = 5,
+) -> list[dict]:
+    """Typo-tolerant text search for proper noun fields (suppliers, codes).
+
+    Uses Typesense's built-in fuzzy matching with prefix support.
+    No embeddings needed — matches on string similarity.
+
+    Args:
+        query: The user's term, e.g. "Pitney" or "Delta Dental".
+        field_name: Which field to search within (e.g. "Supplier Name").
+        limit: Maximum number of results to return.
+
+    Returns:
+        List of dicts with ``value`` and ``score`` keys.
+    """
+    client = get_typesense_client()
+
+    results = client.collections[TYPESENSE_COLLECTION].documents.search({
+        "q": query,
+        "query_by": "value",
+        "filter_by": f"field_name:={field_name}",
+        "per_page": limit,
+        "num_typos": 2,
+        "prefix": "true",
+    })
+
+    return [
+        {
+            "value": hit["document"]["value"],
+            "score": hit["text_match_info"]["score"],
+        }
+        for hit in results["hits"]
     ]

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -38,6 +38,21 @@ with st.sidebar:
         if st.button(example, use_container_width=True, key=f"sem_{example}"):
             st.session_state["pending_query"] = example
 
+    st.divider()
+    st.header("Fuzzy Supplier Search")
+    st.caption(
+        "These use partial or misspelled supplier names resolved via "
+        "typo-tolerant text search (e.g. 'Pitney' \u2192 'Pitney Bowes')."
+    )
+    fuzzy_examples = [
+        "How much did Pitney spend in total?",
+        "Show orders from Delat Dental",
+        "Which suppliers are in zip code 95841?",
+    ]
+    for example in fuzzy_examples:
+        if st.button(example, use_container_width=True, key=f"fuz_{example}"):
+            st.session_state["pending_query"] = example
+
 # --- Chat state ---
 if "messages" not in st.session_state:
     st.session_state.messages = []

--- a/scripts/index_typesense.py
+++ b/scripts/index_typesense.py
@@ -1,4 +1,7 @@
-"""Index distinct MongoDB field values into Typesense for semantic search.
+"""Index distinct MongoDB field values into Typesense.
+
+Semantic fields get vector embeddings for meaning-based search.
+Fuzzy fields get text-only indexing for typo-tolerant matching.
 
 Idempotent: drops and recreates the collection on every run.
 
@@ -18,21 +21,28 @@ from app.config import (
 )
 from app.search import embed_text, get_typesense_client
 
-# Fields whose distinct values we want to make searchable.
-TARGET_FIELDS = [
+# Semantic fields — meaning-based vector search (user paraphrases concepts).
+SEMANTIC_FIELDS = [
     "Department Name",
-    "Supplier Name",
     "Item Name",
     "Acquisition Type",
     "Acquisition Method",
+]
+
+# Fuzzy fields — typo-tolerant text search (proper nouns, codes).
+FUZZY_FIELDS = [
+    "Supplier Name",
+    "Supplier Code",
+    "Supplier Zip Code",
 ]
 
 COLLECTION_SCHEMA = {
     "name": TYPESENSE_COLLECTION,
     "fields": [
         {"name": "field_name", "type": "string", "facet": True},
+        {"name": "search_type", "type": "string", "facet": True},
         {"name": "value", "type": "string"},
-        {"name": "embedding", "type": "float[]", "num_dim": 384},
+        {"name": "embedding", "type": "float[]", "num_dim": 384, "optional": True},
     ],
 }
 
@@ -60,18 +70,38 @@ def main() -> None:
     collection = mongo[DB_NAME][COLLECTION_NAME]
 
     total = 0
-    for field in TARGET_FIELDS:
+
+    # Index semantic fields with embeddings.
+    for field in SEMANTIC_FIELDS:
         values = collection.distinct(field)
         values = [v for v in values if v is not None and str(v).strip()]
-        print(f"  {field}: {len(values)} distinct values")
+        print(f"  {field}: {len(values)} distinct values (semantic)")
 
         for value in values:
             str_value = str(value)
             doc = {
                 "id": _stable_id(field, str_value),
                 "field_name": field,
+                "search_type": "semantic",
                 "value": str_value,
                 "embedding": embed_text(str_value),
+            }
+            client.collections[TYPESENSE_COLLECTION].documents.upsert(doc)
+            total += 1
+
+    # Index fuzzy fields without embeddings.
+    for field in FUZZY_FIELDS:
+        values = collection.distinct(field)
+        values = [v for v in values if v is not None and str(v).strip()]
+        print(f"  {field}: {len(values)} distinct values (fuzzy)")
+
+        for value in values:
+            str_value = str(value)
+            doc = {
+                "id": _stable_id(field, str_value),
+                "field_name": field,
+                "search_type": "fuzzy",
+                "value": str_value,
             }
             client.collections[TYPESENSE_COLLECTION].documents.upsert(doc)
             total += 1

--- a/tests/evaluation.json
+++ b/tests/evaluation.json
@@ -73,5 +73,53 @@
         }
       }
     ]
+  },
+  {
+    "id": "supplier-fuzzy-partial",
+    "tags": ["fuzzy-search", "supplier"],
+    "_comment": "Fuzzy search: partial supplier name 'Pitney' should resolve to 'Pitney Bowes' via typo-tolerant text match.",
+    "question": "How much did Pitney spend in total?",
+    "expected_values": ["Pitney Bowes"],
+    "tool_calls": [
+      {
+        "name": "find_supplier",
+        "args": {
+          "query": "Pitney",
+          "field_name": "Supplier Name"
+        }
+      }
+    ]
+  },
+  {
+    "id": "supplier-fuzzy-typo",
+    "tags": ["fuzzy-search", "supplier"],
+    "_comment": "Fuzzy search: misspelled supplier name should still resolve via typo tolerance.",
+    "question": "Show orders from Delat Dental",
+    "expected_values": ["Delta Dental"],
+    "tool_calls": [
+      {
+        "name": "find_supplier",
+        "args": {
+          "query": "Delat Dental",
+          "field_name": "Supplier Name"
+        }
+      }
+    ]
+  },
+  {
+    "id": "supplier-fuzzy-zip",
+    "tags": ["fuzzy-search", "supplier"],
+    "_comment": "Fuzzy search by supplier zip code.",
+    "question": "Which suppliers are in zip code 95841?",
+    "expected_values": ["95841"],
+    "tool_calls": [
+      {
+        "name": "find_supplier",
+        "args": {
+          "query": "95841",
+          "field_name": "Supplier Zip Code"
+        }
+      }
+    ]
   }
 ]

--- a/tests/integration_tests/test_agent.py
+++ b/tests/integration_tests/test_agent.py
@@ -33,13 +33,17 @@ def _final_response(text):
 # ── Data-driven tests from evaluation.json ───────────────────────────
 
 # Cases that hit Typesense need the search backend mocked.
-_SEARCH_MOCK_RETURN = [
+_SEMANTIC_MOCK_RETURN = [
     {"value": "Health Care Services, Department of", "score": 0.12},
 ]
 
+_FUZZY_MOCK_RETURN = [
+    {"value": "Pitney Bowes", "score": 1234},
+]
 
-def _needs_search_mock(case):
-    return any(tc["name"] == "find_similar_values" for tc in case["tool_calls"])
+
+def _tool_names(case):
+    return {tc["name"] for tc in case["tool_calls"]}
 
 
 @pytest.mark.parametrize(
@@ -57,12 +61,20 @@ def test_tool_dispatch(case, mongo_collection):
     final = _final_response("Done.")
 
     mock_llm = make_mock_llm([tool_call_response, final])
+    names = _tool_names(case)
 
-    if _needs_search_mock(case):
-        with patch(
-            "app.agent.search_similar_values",
-            return_value=_SEARCH_MOCK_RETURN,
-        ):
+    patches = {}
+    if "find_similar_values" in names:
+        patches["app.agent.search_similar_values"] = _SEMANTIC_MOCK_RETURN
+    if "find_supplier" in names:
+        patches["app.agent.search_fuzzy"] = _FUZZY_MOCK_RETURN
+
+    if patches:
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            for target, rv in patches.items():
+                stack.enter_context(patch(target, return_value=rv))
             result = run_agent(case["question"], [], llm=mock_llm)
     else:
         result = run_agent(case["question"], [], llm=mock_llm)
@@ -201,3 +213,100 @@ class TestFindSimilarValues:
 
         assert result == "Found 42 orders."
         assert mock_llm.call_count == 3
+
+
+class TestFindSupplier:
+    """Integration tests for the find_supplier tool.
+
+    These test fuzzy text search for supplier fields — partial names,
+    typos, and zip codes resolved via Typesense typo-tolerant matching.
+
+    Mocks the search backend but exercises the full agent tool-dispatch path.
+    """
+
+    @patch("app.agent.search_fuzzy")
+    def test_partial_supplier_name(self, mock_fuzzy):
+        """Partial name 'Pitney' resolves to 'Pitney Bowes'."""
+        mock_fuzzy.return_value = [
+            {"value": "Pitney Bowes", "score": 1234},
+        ]
+
+        tool_call_response = _ai_with_tool_calls([
+            {
+                "id": "call_0",
+                "name": "find_supplier",
+                "args": {
+                    "query": "Pitney",
+                    "field_name": "Supplier Name",
+                },
+            },
+        ])
+        final = _final_response("The closest match is Pitney Bowes.")
+
+        mock_llm = make_mock_llm([tool_call_response, final])
+        result = run_agent("How much did Pitney spend?", [], llm=mock_llm)
+
+        assert result == "The closest match is Pitney Bowes."
+        mock_fuzzy.assert_called_once_with("Pitney", "Supplier Name", 5)
+
+    @patch("app.agent.search_fuzzy")
+    def test_supplier_then_mongodb_query(self, mock_fuzzy, mongo_collection):
+        """Two-step: resolve supplier name, then query MongoDB."""
+        mock_fuzzy.return_value = [
+            {"value": "Pitney Bowes", "score": 1234},
+        ]
+
+        search_call = _ai_with_tool_calls([
+            {
+                "id": "call_0",
+                "name": "find_supplier",
+                "args": {
+                    "query": "Pitney",
+                    "field_name": "Supplier Name",
+                },
+            },
+        ])
+        mongo_call = _ai_with_tool_calls([
+            {
+                "id": "call_1",
+                "name": "aggregate_mongodb",
+                "args": {
+                    "pipeline": json.dumps([
+                        {"$match": {"Supplier Name": "Pitney Bowes"}},
+                        {"$group": {"_id": None, "total": {"$sum": "$Total Price"}}},
+                    ])
+                },
+            },
+        ])
+        final = _final_response("Pitney Bowes spent $123,456.")
+
+        mock_llm = make_mock_llm([search_call, mongo_call, final])
+        result = run_agent("How much did Pitney spend?", [], llm=mock_llm)
+
+        assert result == "Pitney Bowes spent $123,456."
+        assert mock_llm.call_count == 3
+
+    @patch("app.agent.search_fuzzy")
+    def test_supplier_zip_code(self, mock_fuzzy):
+        """Zip code lookup dispatches find_supplier with Supplier Zip Code."""
+        mock_fuzzy.return_value = [
+            {"value": "95841", "score": 999},
+        ]
+
+        tool_call_response = _ai_with_tool_calls([
+            {
+                "id": "call_0",
+                "name": "find_supplier",
+                "args": {
+                    "query": "95841",
+                    "field_name": "Supplier Zip Code",
+                },
+            },
+        ])
+        final = _final_response("Found suppliers in 95841.")
+
+        mock_llm = make_mock_llm([tool_call_response, final])
+        result = run_agent("Which suppliers are in zip 95841?", [], llm=mock_llm)
+
+        assert result == "Found suppliers in 95841."
+        mock_fuzzy.assert_called_once_with("95841", "Supplier Zip Code", 5)

--- a/tests/unit_tests/test_search.py
+++ b/tests/unit_tests/test_search.py
@@ -1,8 +1,8 @@
-"""Level 1: Unit tests for app/search.py — embedding and vector search."""
+"""Level 1: Unit tests for app/search.py — embedding, vector, and fuzzy search."""
 
 from unittest.mock import MagicMock, patch
 
-from app.search import embed_text, search_similar_values
+from app.search import embed_text, search_fuzzy, search_similar_values
 
 
 class TestEmbedText:
@@ -92,5 +92,79 @@ class TestSearchSimilarValues:
         mock_client_fn.return_value = _mock_multi_search([])
 
         results = search_similar_values("nonexistent", "Department Name")
+
+        assert results == []
+
+
+def _mock_text_search(hits):
+    """Create a mock Typesense client whose collection search returns *hits*."""
+    mock_client = MagicMock()
+    mock_collection = MagicMock()
+    mock_collection.documents.search.return_value = {"hits": hits}
+    mock_client.collections.__getitem__.return_value = mock_collection
+    return mock_client
+
+
+class TestSearchFuzzy:
+    @patch("app.search.get_typesense_client")
+    def test_returns_matches_with_value_and_score(self, mock_client_fn):
+        mock_client_fn.return_value = _mock_text_search([
+            {
+                "document": {
+                    "field_name": "Supplier Name",
+                    "value": "Pitney Bowes",
+                },
+                "text_match_info": {"score": 1234},
+            },
+            {
+                "document": {
+                    "field_name": "Supplier Name",
+                    "value": "Pitney Bowes Inc.",
+                },
+                "text_match_info": {"score": 1100},
+            },
+        ])
+
+        results = search_fuzzy("Pitney", "Supplier Name", limit=2)
+
+        assert len(results) == 2
+        assert results[0]["value"] == "Pitney Bowes"
+        assert results[0]["score"] == 1234
+
+    @patch("app.search.get_typesense_client")
+    def test_passes_typo_tolerance_params(self, mock_client_fn):
+        mock_client_fn.return_value = _mock_text_search([])
+
+        search_fuzzy("Delat Denta", "Supplier Name")
+
+        search_call = (
+            mock_client_fn.return_value
+            .collections.__getitem__.return_value
+            .documents.search
+        )
+        search_args = search_call.call_args[0][0]
+        assert search_args["num_typos"] == 2
+        assert search_args["prefix"] == "true"
+        assert search_args["query_by"] == "value"
+
+    @patch("app.search.get_typesense_client")
+    def test_filters_by_field_name(self, mock_client_fn):
+        mock_client_fn.return_value = _mock_text_search([])
+
+        search_fuzzy("95841", "Supplier Zip Code")
+
+        search_call = (
+            mock_client_fn.return_value
+            .collections.__getitem__.return_value
+            .documents.search
+        )
+        search_args = search_call.call_args[0][0]
+        assert search_args["filter_by"] == "field_name:=Supplier Zip Code"
+
+    @patch("app.search.get_typesense_client")
+    def test_empty_results(self, mock_client_fn):
+        mock_client_fn.return_value = _mock_text_search([])
+
+        results = search_fuzzy("nonexistent", "Supplier Name")
 
         assert results == []


### PR DESCRIPTION
## Summary
- Add `find_supplier` tool using Typesense typo-tolerant text search for Supplier Name, Supplier Code, and Supplier Zip Code
- Split indexing into semantic fields (with embeddings) and fuzzy fields (text-only)
- Add `search_fuzzy()` in `app/search.py` with `num_typos: 2` and prefix matching

## Test plan
- [ ] Re-index with `python scripts/index_typesense.py`
- [ ] Unit tests: `pytest tests/unit_tests/ -k fuzzy` (4 tests)
- [ ] Integration tests: `pytest tests/integration_tests/ -k supplier` (3 tests)
- [ ] Streamlit sidebar: try "How much did Pitney spend?" and "Show orders from Delat Dental"

🤖 Generated with [Claude Code](https://claude.com/claude-code)